### PR TITLE
Configuração de user.site de cabecalho Resolve #40

### DIFF
--- a/cabecalho
+++ b/cabecalho
@@ -130,7 +130,7 @@ case "$1" in
 
 		if [ -f "$CONFIG" ]
 		then
-			sed -n '/^#/!p' "$CONFIG"
+			sed -n '/^#/!p' "$CONFIG" | tr '§' '/'
 		else
 			criarPastaArquivosConfig "$CONFIG"
 		fi
@@ -149,7 +149,7 @@ case "$1" in
 		}
 
 		VARIAVEL_FORNECIDA=$(echo "$2" | cut -d"=" -f1)
-		VALOR_FORNECIDO=$(echo "$2" | cut -d"=" -f2)
+		VALOR_FORNECIDO=$(echo "$2" | cut -d"=" -f2 | tr "/" '§')
 
 		if [ -f "$CONFIG" ]
 		then
@@ -177,7 +177,7 @@ esac
 # definido em .config/cabecalho.config.txt
 [ -f "$CONFIG" ] && {
 
-	TMP=$(sed -n '/^#/!p' "$CONFIG")
+	TMP=$(sed -n '/^#/!p' "$CONFIG" | tr '§' '/')
 	PROGRAMADOR=$(echo "$TMP" | grep "user.programador" | cut -d"=" -f2)
 	SITE=$(echo "$TMP" | grep "user.site" | cut -d"=" -f2)
 	EMAIL=$(echo "$TMP" | grep "user.email" | cut -d"=" -f2)


### PR DESCRIPTION
:outbox_tray: **Pull Request**

**Descrição**

Corrige a configuração da variável user.site. O problema surgiu porque o
caractere '/' é utilizado como terminador das regex do comando sed. Ao
fornecer uma url, como no caso de user.site=http://dirack.github.io, o sed
confunde a '/' com a terminação do comando e apresenta o erro.

Resolve #40 

**Tipo da modificação**

- [x] Correção de Bug (modificação que corrige uma problema)
- [ ] Nova feature (modificação que adiciona uma funcionalidade)
- [ ] Atualização de documentação
- [ ] Outros (_Descrever aqui_)

**Adicione imagens abaixo e o contexto se necessário**

A solução foi acrescentar um caractere especial '§' no lugar da '/' e
parsear este caractere utilizando o comando tr.

O comando grep não consegue ler o caractere '§' corretamente, a solução
é também parsear o caractere especial com tr antes de fornecer ao grep.
Como os dados são lidos e armaznados na variável TMP antes de serem
lidos pelo grep, basta parsear a variável.
