### PR TITLE
Feature/issue/27

### DIFF
--- a/madagainstall
+++ b/madagainstall
@@ -71,7 +71,7 @@ case "$1" in
 		else
 			if tar -xzvf "$HOME/madagascar-3.0.1.tar.gz" -C "$HOME" &>/dev/null
 			then
-				cd ${HOME}/madagascar-3.0
+				echo "...Arquivo descompactado com sucesso em $HOME/madagascar-3.0"
 			else
 
 				MENSAGEMERRO="Ocorreu um erro inesperado ao descompactar o pacote em $HOME/madagascar-3.0"
@@ -91,7 +91,7 @@ case "$1" in
 		
 		# Configuração do madagascar
 		echo -e "Configurar o Madagascar para instalacao...\n"
-		./configure --prefix=$HOME/madagascar
+		$HOME/madagascar-3.0/configure --prefix=$HOME/madagascar
 
 		# Instalação do pacote Madagascar	
 		echo -e "Instalar o pacote Madagascar...\n"

--- a/madagainstall
+++ b/madagainstall
@@ -101,13 +101,23 @@ case "$1" in
 			export DATAPATH=$HOME/rsfdata/
 			echo "source $HOME/madagascar/share/madagascar/etc/env.sh" >> "$HOME/.bashrc"
 			echo "export DATAPATH=$HOME/rsfdata/" >> "$HOME/.bashrc"
+			source "$HOME/.bashrc"
+			echo "Testando a instalação..."
+			if sfspike n1=100 k1=30 | sfbandpass fhi=2 phase=y | sfwiggle clip=0.02 title="Welcome to Madagascar" | sfpen
+			then
+				echo "...Instalação finalizada com sucesso! :)"
+			else
+				MENSAGEMERRO="Ocorreu um erro inesperado durante a instalação do pacote Madagascar!"
+				exibirMensagemErroProgramaFormatada "$(basename $0)" "4" "$MENSAGEMERRO"
+
+			fi
 		else
 			MENSAGEMERRO="Ocorreu um erro inesperado durante a instalação do pacote Madagascar!"
-			exibirMensagemErroProgramaFormatada "$(basename $0)" "3" "$MENSAGEMERRO"
+			exibirMensagemErroProgramaFormatada "$(basename $0)" "5" "$MENSAGEMERRO"
 		fi
 	;;
 
 	*)
 		MENSAGEMERRO="Opção $1 Desconhecida!\nDigite $(basename $0) -h para obter ajuda"
-		exibirMensagemErroProgramaFormatada "$(basename $0)" "4" "$MENSAGEMERRO"
+		exibirMensagemErroProgramaFormatada "$(basename $0)" "6" "$MENSAGEMERRO"
 esac

--- a/madagainstall
+++ b/madagainstall
@@ -115,8 +115,8 @@ case "$1" in
 			}
 
 			source "$HOME/.bashrc"
-			echo "Testando a instalação..."
-			if sfspike n1=100 k1=30 | sfdisfil
+			echo "Testando a instalação... Rodando sfspike..."
+			if sfspike n1=20 k1=3 | sfdisfil
 			then
 				echo -e "...Instalação finalizada com sucesso! :)\n"
 				echo -e "Para utilizar o Madagascar neste terminal carregue as variáveis de ambiente com:\nsource $HOME/.bashrc\nOu abra um novo terminal...\n"

--- a/madagainstall
+++ b/madagainstall
@@ -65,7 +65,7 @@ case "$1" in
                 fi
 
                 echo -e "Descompactando a versão 3.0 do pacote Madagascar...\n"
-		if [ "-f" "$HOME/madagascar-3.0" ]
+		if [ "-d" "$HOME/madagascar-3.0" ]
 		then
 			echo -e "...Já existe uma versão descompactada do pacote Madagascar em $HOME\n"
 		else

--- a/madagainstall
+++ b/madagainstall
@@ -117,7 +117,9 @@ case "$1" in
 			if sfspike n1=100 k1=30 | sfdisfil
 			then
 				echo -e "...Instalação finalizada com sucesso! :)\n"
-				echo -e "Para utilizar o Madagascar neste terminal carregue as variáveis de ambiente com:\nsource $HOME/.bashrc\nOu abra um novo terminal..."
+				echo -e "Para utilizar o Madagascar neste terminal carregue as variáveis de ambiente com:\nsource $HOME/.bashrc\nOu abra um novo terminal...\n"
+				echo -e "Teste a interface gráfica do pacote com o comando a seguir: " 
+				echo -e "sfspike n1=1000 k1=300 | sfbandpass fhi=2 phase=y | sfwiggle clip=0.02 title="Welcome to Madagascar" | sfpen"
 			else
 				MENSAGEMERRO="Ocorreu um erro inesperado durante a instalação do pacote Madagascar!"
 				exibirMensagemErroProgramaFormatada "$(basename $0)" "4" "$MENSAGEMERRO"

--- a/madagainstall
+++ b/madagainstall
@@ -100,8 +100,18 @@ case "$1" in
 			# Definição das variáveis de ambiente do Madagascar no .bashrc
 			export DATAPATH=$HOME/rsfdata/
 			source "$HOME/madagascar/share/madagascar/etc/env.sh"
-			echo "source $HOME/madagascar/share/madagascar/etc/env.sh" >> "$HOME/.bashrc"
-			echo "export DATAPATH=$HOME/rsfdata/" >> "$HOME/.bashrc"
+
+			# Verificar se as variáveis de ambiente já estão setadas corretamente
+			grep -xq "source $HOME/madagascar/share/madagascar/etc/env.sh" "$HOME/.bashrc"
+			[ "$?" -ne "0" ] && {
+				echo "source $HOME/madagascar/share/madagascar/etc/env.sh" >> "$HOME/.bashrc"
+			}
+
+			grep -xq "export DATAPATH=$HOME/rsfdata/" "$HOME/.bashrc"
+			[ "$?" -ne "0" ] && {
+				echo "export DATAPATH=$HOME/rsfdata/" >> "$HOME/.bashrc"
+			}
+
 			source "$HOME/.bashrc"
 			echo "Testando a instalação..."
 			if sfspike n1=100 k1=30 | sfdisfil

--- a/madagainstall
+++ b/madagainstall
@@ -1,0 +1,153 @@
+#!/bin/bash
+#
+# madagainstall (Shell Script)
+# 
+# Objetivo: Script de instalação do pacote de processamento sísmico Madagascar.
+# 
+# Site: https://dirack.github.io
+# 
+# Versão 1.2
+# 
+# Programador:  Murilo Santiago (Original-1.0) 23/03/2020
+#
+# Programador:	Rodolfo A C Neves (Dirack) (Atualização-1.2) 24/03/2020
+#		-Incorporação à biblioteca Shellinclude
+#
+# Email: rodolfo_profissional@hotmail.com
+# 
+# Licença: GPL-3.0 <https://www.gnu.org/licenses/gpl-3.0.txt>.
+
+# Biblioteca de funções para formatar a mensagem de ajuda
+source mensagemAjuda.sh 
+
+# Biblioteca de funções para formatar a mensagem de erro
+source mensagemErro.sh
+
+## Verificar se o usuário forneceu $1 e $2
+if [ -z "$1" ]
+then
+	MENSAGEMERRO="Usuário não ofereceu parâmetros ao programa!\nDigite $(basename $0) -h para obter ajuda!"
+	exibirMensagemErroProgramaFormatada "$(basename $0)" "1" "$MENSAGEMERRO"
+fi
+
+# Versão deste programa
+VERSAO="Shellinclude - Versão 1.2"
+
+## Variáveis que armazenam mensagem de ajuda do programa
+NOME_PROGRAMA="$(basename $0)"
+DESCRICAO="Script de instalação do pacote de processamento sísmico Madagascar."
+PARAMETROS="-h --help::Exibe essa tela de ajuda e sai
+-v --version::Exibe a versão do programa e sai
+-i --install::Instalar o Madagascar na pasta atual"
+EXEMPLO_DE_USO="~$ $(basename $0) -i # Instalação do Madagascar na pasta atual"
+
+case "$1" in
+	-h | --help) ## Exibe a ajuda
+		clear
+		exibirMensagemAjudaProgramaFormatada "$NOME_PROGRAMA" "$DESCRICAO" "$PARAMETROS" "$EXEMPLO_DE_USO"
+		exit 0
+	;;
+
+	-v | --version) ## Exibe a versão do programa
+		echo $VERSAO
+		exit 0
+	;;
+
+	-i | --install) ## Instalar o pacote Madagascar na pasta atual
+		#!/bin/bash
+		#limpado o terminal:
+		clear
+		# diretorio de instalacao home
+		cd ${HOME}
+		#iniciando a instalacao:
+		echo ""
+		echo "========================================================================"
+		echo "	Instalação do madagascar-2.0.1 (UBUNTU 18.04)"
+		echo "========================================================================"
+		sleep 5
+		#criando diretorio de instalacao:
+		mkdir madagascar
+		mkdir rsfdata
+		echo ""
+		echo "========================================================================"
+		echo "	Criando diretorio de instalacao:"
+		echo "${PWD}"
+		echo "========================================================================" 
+		#sleep 20
+		#download:
+		echo ""
+		echo "========================================================================"
+		echo "	Baixando o madagascar:"
+		echo "========================================================================" 
+		echo ""
+		wget -c https://ufpr.dl.sourceforge.net/project/rsf/madagascar/madagascar-3.0/madagascar-3.0.1.tar.gz
+		#descompactando:
+		echo ""
+		echo "========================================================================"
+		echo "Descompactando o madagascar:"
+		echo "========================================================================"
+		#mv madagascar-3.0.1.tar.gz $HOME
+		tar -xzvf madagascar-3.0.1.tar.gz
+		# fazendo update antes da atualizacao dos repositorios
+		echo "========================================================================"
+		echo "	Digite a senha de super usuario, para atualizar os repositorios:"
+		echo "========================================================================"
+		if ! sudo apt-get update
+		then
+		echo "========================================================================"
+		echo "	Não foi possível atualizar os repositórios. Verifique seu arquivo /etc/apt/sources.list"
+		echo "========================================================================"
+		echo ""
+		exit 1
+		fi
+		echo "========================================================================"
+		echo "	Atualização feita com sucesso"
+		echo "========================================================================"
+		#pacotes necessarios para instalacao:
+		sudo apt-get install libxaw7-dev freeglut3-dev libnetpbm10-dev libgd-dev libplplot-dev \
+		libavcodec-dev libcairo2-dev libjpeg-dev swig python-dev python-numpy g++ gfortran \
+		libopenmpi-dev libfftw3-dev libsuitesparse-dev python-epydoc scons git emacs25
+		#entrando na pasta:
+		cd ${HOME}/madagascar-3.0
+		#configurando o madagascar:
+		echo ""
+		echo "========================================================================"
+		echo "	Configurando o madagascar para instalacao:"
+		echo "========================================================================"
+		echo ""
+		sleep 5
+		./configure --prefix=/home/$USER/madagascar
+		#sudo make install:
+		echo ""
+		echo "========================================================================"
+		echo "	sudo make install:"
+		echo "========================================================================"
+		echo ""
+		sudo make install
+		echo ""
+		echo "========================================================================"
+		echo "	Configurando o seu bash: "
+		echo "========================================================================"
+		echo ""
+		cd ${HOME}
+		#verificar futuramente uma nova iplementacao 
+		#source /home/$USER/madagascar/share/madagascar/etc/env.sh
+		#export PYTHONPATH=$PYTHONPATH:/home/$USER/madagascar/lib/python2.7/dist-packages/rsf:/home/$USER/madagascar/lib/python2.7/distpackages/rsf/recipes
+		export DATAPATH=/home/$USER/rsfdata/
+		#exportando para o .bashrc:
+		variable1="source /home/$USER/madagascar/share/madagascar/etc/env.sh"
+		echo $variable1 >> .bashrc
+		#variable2="export PYTHONPATH=$PYTHONPATH:/home/$USER/madagascar/lib/python2.7/dist-packages/rsf:/home/$USER/madagascar/lib/python2.7/distpackages/rsf/recipes"
+		#echo $variable2 >> .bashrc
+		variable3="export DATAPATH=/home/$USER/rsfdata/"
+		echo $variable3 >> .bashrc
+		echo ""
+		echo "========================================================================"
+		echo "Instalação finalizada com sucesso !!!"
+		echo "========================================================================"
+	;;
+
+	*)
+		MENSAGEMERRO="Opção $1 Desconhecida!\nDigite $(basename $0) -h para obter ajuda"
+		exibirMensagemErroProgramaFormatada "$(basename $0)" "4" "$MENSAGEMERRO"
+esac

--- a/madagainstall
+++ b/madagainstall
@@ -38,8 +38,8 @@ NOME_PROGRAMA="$(basename $0)"
 DESCRICAO="Script de instalação do pacote de processamento sísmico Madagascar."
 PARAMETROS="-h --help::Exibe essa tela de ajuda e sai
 -v --version::Exibe a versão do programa e sai
--i --install::Instalar o Madagascar na pasta atual"
-EXEMPLO_DE_USO="~$ $(basename $0) -i # Instalação do Madagascar na pasta atual"
+-i --install::Instalar o Madagascar na pasta $HOME"
+EXEMPLO_DE_USO="~$ $(basename $0) -i # Instalar o Madagascar"
 
 case "$1" in
 	-h | --help) ## Exibe a ajuda

--- a/madagainstall
+++ b/madagainstall
@@ -103,9 +103,10 @@ case "$1" in
 			echo "export DATAPATH=$HOME/rsfdata/" >> "$HOME/.bashrc"
 			source "$HOME/.bashrc"
 			echo "Testando a instalação..."
-			if sfspike n1=100 k1=30 | sfbandpass fhi=2 phase=y | sfwiggle clip=0.02 title="Welcome to Madagascar" | sfpen
+			if sfspike n1=100 k1=30 | sfdisfil
 			then
-				echo "...Instalação finalizada com sucesso! :)"
+				echo -e "...Instalação finalizada com sucesso! :)\n"
+				echo -e "Para utilizar o Madagascar neste terminal carregue as variáveis de ambiente com:\nsource $HOME/.bashrc\nOu abra um novo terminal..."
 			else
 				MENSAGEMERRO="Ocorreu um erro inesperado durante a instalação do pacote Madagascar!"
 				exibirMensagemErroProgramaFormatada "$(basename $0)" "4" "$MENSAGEMERRO"

--- a/madagainstall
+++ b/madagainstall
@@ -65,14 +65,19 @@ case "$1" in
                 fi
 
                 echo -e "Descompactando a versão 3.0 do pacote Madagascar...\n"
-                if tar -xzvf "$HOME/madagascar-3.0.1.tar.gz" -C "$HOME" &>/dev/null
-                then
-                        cd ${HOME}/madagascar-3.0
-                else
+		if [ "-f" "$HOME/madagascar-3.0" ]
+		then
+			echo -e "...Já existe uma versão descompactada do pacote Madagascar em $HOME\n"
+		else
+			if tar -xzvf "$HOME/madagascar-3.0.1.tar.gz" -C "$HOME" &>/dev/null
+			then
+				cd ${HOME}/madagascar-3.0
+			else
 
-                        MENSAGEMERRO="Ocorreu um erro inesperado ao descompactar o pacote em $HOME/madagascar-3.0"
-                        exibirMensagemErroProgramaFormatada "$(basename $0)" "2" "$MENSAGEMERRO"
-                fi
+				MENSAGEMERRO="Ocorreu um erro inesperado ao descompactar o pacote em $HOME/madagascar-3.0"
+				exibirMensagemErroProgramaFormatada "$(basename $0)" "2" "$MENSAGEMERRO"
+			fi
+		fi
 
 		# Instalar dependências
 		DEPENDENCIAS="libxaw7-dev freeglut3-dev libnetpbm10-dev libgd-dev libplplot-dev libavcodec-dev libcairo2-dev libjpeg-dev swig python-dev python-numpy g++ gfortran libopenmpi-dev libfftw3-dev libsuitesparse-dev python-epydoc scons git emacs25"
@@ -81,7 +86,7 @@ case "$1" in
 		for i in $DEPENDENCIAS
 		do
 			echo "...Instalando $i"
-			sudo apt-get install -y "$i" &>/dev/null
+			sudo apt-get install -y "$i" 1>/dev/null
 		done
 		
 		# Configuração do madagascar

--- a/madagainstall
+++ b/madagainstall
@@ -99,8 +99,8 @@ case "$1" in
 		then
 			# Definição das variáveis de ambiente do Madagascar no .bashrc
 			export DATAPATH=$HOME/rsfdata/
-			echo "source $HOME/madagascar/share/madagascar/etc/env.sh" >> .bashrc
-			echo "export DATAPATH=$HOME/rsfdata/" >> .bashrc
+			echo "source $HOME/madagascar/share/madagascar/etc/env.sh" >> "$HOME/.bashrc"
+			echo "export DATAPATH=$HOME/rsfdata/" >> "$HOME/.bashrc"
 		else
 			MENSAGEMERRO="Ocorreu um erro inesperado durante a instalação do pacote Madagascar!"
 			exibirMensagemErroProgramaFormatada "$(basename $0)" "3" "$MENSAGEMERRO"

--- a/madagainstall
+++ b/madagainstall
@@ -68,10 +68,12 @@ case "$1" in
 		if [ "-d" "$HOME/madagascar-3.0" ]
 		then
 			echo -e "...Já existe uma versão descompactada do pacote Madagascar em $HOME\n"
+			cd "$HOME/madagascar-3.0"
 		else
 			if tar -xzvf "$HOME/madagascar-3.0.1.tar.gz" -C "$HOME" &>/dev/null
 			then
 				echo "...Arquivo descompactado com sucesso em $HOME/madagascar-3.0"
+				cd "$HOME/madagascar-3.0"
 			else
 
 				MENSAGEMERRO="Ocorreu um erro inesperado ao descompactar o pacote em $HOME/madagascar-3.0"
@@ -91,7 +93,7 @@ case "$1" in
 		
 		# Configuração do madagascar
 		echo -e "Configurar o Madagascar para instalacao...\n"
-		$HOME/madagascar-3.0/configure --prefix=$HOME/madagascar
+		./configure --prefix=$HOME/madagascar
 
 		# Instalação do pacote Madagascar	
 		echo -e "Instalar o pacote Madagascar...\n"

--- a/madagainstall
+++ b/madagainstall
@@ -56,34 +56,49 @@ case "$1" in
 	-i | --install) ## Instalar o pacote Madagascar na pasta atual
 		
 		URL="https://ufpr.dl.sourceforge.net/project/rsf/madagascar/madagascar-3.0/madagascar-3.0.1.tar.gz"
-		echo "Baixando o pacote madagascar do servidor ${URL}..."
-		wget -c "$URL" > ${HOME}
+		echo -e "\nBaixando o pacote madagascar do servidor ${URL}...\n"
+                if [ -f "$HOME/madagascar-3.0.1.tar.gz" ]
+                then
+                        echo -e "...Já existe uma versão do pacote Madagascar em $HOME\n"
+                else
+                        wget -c "$URL" -P ${HOME} &>/dev/null
+                fi
 
-		tar -xzvf "~/madagascar-3.0.1.tar.gz"
+                echo -e "Descompactando a versão 3.0 do pacote Madagascar...\n"
+                if tar -xzvf "$HOME/madagascar-3.0.1.tar.gz" -C "$HOME" &>/dev/null
+                then
+                        cd ${HOME}/madagascar-3.0
+                else
 
-		cd ${HOME}/madagascar-3.0
+                        MENSAGEMERRO="Ocorreu um erro inesperado ao descompactar o pacote em $HOME/madagascar-3.0"
+                        exibirMensagemErroProgramaFormatada "$(basename $0)" "2" "$MENSAGEMERRO"
+                fi
 
 		# Instalar dependências
 		DEPENDENCIAS="libxaw7-dev freeglut3-dev libnetpbm10-dev libgd-dev libplplot-dev libavcodec-dev libcairo2-dev libjpeg-dev swig python-dev python-numpy g++ gfortran libopenmpi-dev libfftw3-dev libsuitesparse-dev python-epydoc scons git emacs25"
 
-		echo "Instalar dependências..."
+		echo -e "Instalar dependências...\n"
 		for i in $DEPENDENCIAS
 		do
 			sudo apt-get install "$i"
 		done
 		
 		# Configuração do madagascar
-		echo "	Configurar o Madagascar para instalacao..."
+		echo -e "Configurar o Madagascar para instalacao...\n"
 		./configure --prefix=$HOME/madagascar
 
 		# Instalação do pacote Madagascar	
-		echo "Instalar o pacote Madagascar..."
-		sudo make install
-	
-		# Definição das variáveis de ambiente do Madagascar no .bashrc
-		export DATAPATH=$HOME/rsfdata/
-		echo "source $HOME/madagascar/share/madagascar/etc/env.sh" >> .bashrc
-		echo "export DATAPATH=$HOME/rsfdata/" >> .bashrc
+		echo -e "Instalar o pacote Madagascar...\n"
+		if sudo make install
+		then
+			# Definição das variáveis de ambiente do Madagascar no .bashrc
+			export DATAPATH=$HOME/rsfdata/
+			echo "source $HOME/madagascar/share/madagascar/etc/env.sh" >> .bashrc
+			echo "export DATAPATH=$HOME/rsfdata/" >> .bashrc
+		else
+			MENSAGEMERRO="Ocorreu um erro inesperado durante a instalação do pacote Madagascar!"
+			exibirMensagemErroProgramaFormatada "$(basename $0)" "3" "$MENSAGEMERRO"
+		fi
 	;;
 
 	*)

--- a/madagainstall
+++ b/madagainstall
@@ -80,7 +80,8 @@ case "$1" in
 		echo -e "Instalar dependências...\n"
 		for i in $DEPENDENCIAS
 		do
-			sudo apt-get install "$i"
+			echo "...Instalando $i"
+			sudo apt-get install -y "$i" &>/dev/null
 		done
 		
 		# Configuração do madagascar

--- a/madagainstall
+++ b/madagainstall
@@ -54,97 +54,36 @@ case "$1" in
 	;;
 
 	-i | --install) ## Instalar o pacote Madagascar na pasta atual
-		#!/bin/bash
-		#limpado o terminal:
-		clear
-		# diretorio de instalacao home
-		cd ${HOME}
-		#iniciando a instalacao:
-		echo ""
-		echo "========================================================================"
-		echo "	Instalação do madagascar-2.0.1 (UBUNTU 18.04)"
-		echo "========================================================================"
-		sleep 5
-		#criando diretorio de instalacao:
-		mkdir madagascar
-		mkdir rsfdata
-		echo ""
-		echo "========================================================================"
-		echo "	Criando diretorio de instalacao:"
-		echo "${PWD}"
-		echo "========================================================================" 
-		#sleep 20
-		#download:
-		echo ""
-		echo "========================================================================"
-		echo "	Baixando o madagascar:"
-		echo "========================================================================" 
-		echo ""
-		wget -c https://ufpr.dl.sourceforge.net/project/rsf/madagascar/madagascar-3.0/madagascar-3.0.1.tar.gz
-		#descompactando:
-		echo ""
-		echo "========================================================================"
-		echo "Descompactando o madagascar:"
-		echo "========================================================================"
-		#mv madagascar-3.0.1.tar.gz $HOME
-		tar -xzvf madagascar-3.0.1.tar.gz
-		# fazendo update antes da atualizacao dos repositorios
-		echo "========================================================================"
-		echo "	Digite a senha de super usuario, para atualizar os repositorios:"
-		echo "========================================================================"
-		if ! sudo apt-get update
-		then
-		echo "========================================================================"
-		echo "	Não foi possível atualizar os repositórios. Verifique seu arquivo /etc/apt/sources.list"
-		echo "========================================================================"
-		echo ""
-		exit 1
-		fi
-		echo "========================================================================"
-		echo "	Atualização feita com sucesso"
-		echo "========================================================================"
-		#pacotes necessarios para instalacao:
-		sudo apt-get install libxaw7-dev freeglut3-dev libnetpbm10-dev libgd-dev libplplot-dev \
-		libavcodec-dev libcairo2-dev libjpeg-dev swig python-dev python-numpy g++ gfortran \
-		libopenmpi-dev libfftw3-dev libsuitesparse-dev python-epydoc scons git emacs25
-		#entrando na pasta:
+		
+		URL="https://ufpr.dl.sourceforge.net/project/rsf/madagascar/madagascar-3.0/madagascar-3.0.1.tar.gz"
+		echo "Baixando o pacote madagascar do servidor ${URL}..."
+		wget -c "$URL" > ${HOME}
+
+		tar -xzvf "~/madagascar-3.0.1.tar.gz"
+
 		cd ${HOME}/madagascar-3.0
-		#configurando o madagascar:
-		echo ""
-		echo "========================================================================"
-		echo "	Configurando o madagascar para instalacao:"
-		echo "========================================================================"
-		echo ""
-		sleep 5
-		./configure --prefix=/home/$USER/madagascar
-		#sudo make install:
-		echo ""
-		echo "========================================================================"
-		echo "	sudo make install:"
-		echo "========================================================================"
-		echo ""
+
+		# Instalar dependências
+		DEPENDENCIAS="libxaw7-dev freeglut3-dev libnetpbm10-dev libgd-dev libplplot-dev libavcodec-dev libcairo2-dev libjpeg-dev swig python-dev python-numpy g++ gfortran libopenmpi-dev libfftw3-dev libsuitesparse-dev python-epydoc scons git emacs25"
+
+		echo "Instalar dependências..."
+		for i in $DEPENDENCIAS
+		do
+			sudo apt-get install "$i"
+		done
+		
+		# Configuração do madagascar
+		echo "	Configurar o Madagascar para instalacao..."
+		./configure --prefix=$HOME/madagascar
+
+		# Instalação do pacote Madagascar	
+		echo "Instalar o pacote Madagascar..."
 		sudo make install
-		echo ""
-		echo "========================================================================"
-		echo "	Configurando o seu bash: "
-		echo "========================================================================"
-		echo ""
-		cd ${HOME}
-		#verificar futuramente uma nova iplementacao 
-		#source /home/$USER/madagascar/share/madagascar/etc/env.sh
-		#export PYTHONPATH=$PYTHONPATH:/home/$USER/madagascar/lib/python2.7/dist-packages/rsf:/home/$USER/madagascar/lib/python2.7/distpackages/rsf/recipes
-		export DATAPATH=/home/$USER/rsfdata/
-		#exportando para o .bashrc:
-		variable1="source /home/$USER/madagascar/share/madagascar/etc/env.sh"
-		echo $variable1 >> .bashrc
-		#variable2="export PYTHONPATH=$PYTHONPATH:/home/$USER/madagascar/lib/python2.7/dist-packages/rsf:/home/$USER/madagascar/lib/python2.7/distpackages/rsf/recipes"
-		#echo $variable2 >> .bashrc
-		variable3="export DATAPATH=/home/$USER/rsfdata/"
-		echo $variable3 >> .bashrc
-		echo ""
-		echo "========================================================================"
-		echo "Instalação finalizada com sucesso !!!"
-		echo "========================================================================"
+	
+		# Definição das variáveis de ambiente do Madagascar no .bashrc
+		export DATAPATH=$HOME/rsfdata/
+		echo "source $HOME/madagascar/share/madagascar/etc/env.sh" >> .bashrc
+		echo "export DATAPATH=$HOME/rsfdata/" >> .bashrc
 	;;
 
 	*)

--- a/madagainstall
+++ b/madagainstall
@@ -99,6 +99,7 @@ case "$1" in
 		then
 			# Definição das variáveis de ambiente do Madagascar no .bashrc
 			export DATAPATH=$HOME/rsfdata/
+			source "$HOME/madagascar/share/madagascar/etc/env.sh"
 			echo "source $HOME/madagascar/share/madagascar/etc/env.sh" >> "$HOME/.bashrc"
 			echo "export DATAPATH=$HOME/rsfdata/" >> "$HOME/.bashrc"
 			source "$HOME/.bashrc"


### PR DESCRIPTION
:outbox_tray: **Pull Request**

**Descrição**

Programa madagainstall, script de instalação do pacote Madagascar versão 3.0.

Resolve #27 

**Tipo da modificação**

- [ ] Correção de Bug (modificação que corrige uma problema)
- [x] Nova feature (modificação que adiciona uma funcionalidade)
- [ ] Atualização de documentação
- [ ] Outros (_Descrever aqui_)

**Adicione imagens abaixo e o contexto se necessário**

O programa madagainstall possui as seguintes opções:

- **h --help** Exibe essa tela de ajuda e sai
- **v --version** Exibe a versão do programa e sai
- **-i --install** Instalar o Madagascar na pasta atual

Para instalar a versão 3.0 do pacote Madagascar na pasta $HOME, basta usar o comando:

```sh
~$ madagainstall -i
```
O programa madagainstall baixa a versão 3.0 do pacote Madagascar do sevidor https://ufpr.dl.sourceforge.net/project/rsf/madagascar/madagascar-3.0/madagascar-3.0.1.tar.gz, instala as dependências, o pacote Madagascar e configura as variáveis de ambiente no arquivo $HOME/.bashrc
