### PR TITLE
Feature/issue/48 e hotfix/issue/49

### DIFF
--- a/TDD/lipsum_tdd.sh
+++ b/TDD/lipsum_tdd.sh
@@ -19,3 +19,16 @@ source $(dirname $0)/tdd_lib.sh
 # Testar se lipsum exibe a quantidade de linhas pedidas corretamente
 error "$(lipsum -r | wc -l)" "1" "1" "Exibir uma linha com lipsum -r"
 error "$(lipsum -r 10 | wc -l)" "10" "2" "Exibir 10 linhas com lipsum -r 10"
+
+# Testar condição limite
+total="1000"
+for i in $(seq $total)
+do
+	echo -ne "Rodando lipsum repetidamente ($i/$total)\r\r"
+	LINHAS=$(lipsum -r | wc -l)
+	if [ "$LINHAS" -ne "1" ]
+	then
+		echo " "
+		error "$LINHAS" "1" "3" "Exibir uma linha com lipsum -r"
+	fi
+done

--- a/TDD/lipsum_tdd.sh
+++ b/TDD/lipsum_tdd.sh
@@ -24,7 +24,7 @@ error "$(lipsum -r 10 | wc -l)" "10" "2" "Exibir 10 linhas com lipsum -r 10"
 total="1000"
 for i in $(seq $total)
 do
-	echo -ne "Rodando lipsum repetidamente ($i/$total)\r\r"
+	echo -ne "\tRodando lipsum repetidamente ($i/$total)\r\r"
 	LINHAS=$(lipsum -r | wc -l)
 	if [ "$LINHAS" -ne "1" ]
 	then
@@ -32,3 +32,5 @@ do
 		error "$LINHAS" "1" "3" "Exibir uma linha com lipsum -r"
 	fi
 done
+
+error "$LINHAS" "1" "3" "Rodando lipsum repetidamente ($total/$total)"

--- a/lipsum
+++ b/lipsum
@@ -102,7 +102,7 @@ case "$1" in
 
 		for i in $(seq "$NUM_LINHAS")
 		do
-			LINHA=$(echo "$RANDOM % $TOTAL_LINHAS" | bc )
+			LINHA=$(echo "$RANDOM % $TOTAL_LINHAS + 1" | bc )
 			sed -n "${LINHA}p" "$CONFIG"
 		done
 	;;


### PR DESCRIPTION
:outbox_tray: **Pull Request**

**Descrição**

Corrige bug no programa lipsum e define teste.

Resolve #49 

**Tipo da modificação**

- [x] Correção de Bug (modificação que corrige uma problema)
- [ ] Nova feature (modificação que adiciona uma funcionalidade)
- [ ] Atualização de documentação
- [x] Outros (Testes do programa lipsum)

**Adicione imagens abaixo e o contexto se necessário**

Roda o programa lipsum 1000 vezes para verificar se o número de linhas solicitadas corresponde ao número de linhas da saída do programa.

No bug referenciado na issue #49, o programa lipsum exibia uma linha a menos na saída, pois estava incluindo o zero no intervalo de números aleatórios que utiliza para buscar uma linha qualquer em um arquivo de template. 

Basta somar 1 ao resuldo da geração de números aleatórios para redefinir de [0,TOTAL_LINHAS] para o intervalo [1,TOTAL_LINHAS]. O diff do código fonte do programa:

```diff
          for i in $(seq "$NUM_LINHAS")
                do
-                       LINHA=$(echo "$RANDOM % $TOTAL_LINHAS" | bc )
+                       LINHA=$(echo "$RANDOM % $TOTAL_LINHAS + 1" | bc )
                        sed -n "${LINHA}p" "$CONFIG"
                done
```